### PR TITLE
fix: Skip service subtypes in service type enumeration

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -195,8 +195,9 @@ impl AppState {
 }
 
 fn is_valid_service_type(service_type: &str) -> bool {
-    // all other cases are caught by ServiceDaemon::browse
-    !service_type.starts_with("_sub.")
+    // Just ignore subtypes in enumeration, other
+    // invalid types are covered by browse resulting in an error
+    !service_type.contains("_sub.")
 }
 
 fn ui(f: &mut Frame, app_state: &mut AppState) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service type validation to more strictly filter and reject invalid service types, enhancing accuracy in service categorization across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->