### PR TITLE
fix: Ignore key release events on windows to prevent duplicate events

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -657,6 +657,13 @@ pub async fn run_tui() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(event) = event_result {
                     match event {
                         Event::Key(key) => {
+                            #[cfg(target_os = "windows")]
+                            {
+                                // On Windows, ignore key release events to prevent duplicate handling
+                                if key.kind == crossterm::event::KeyEventKind::Release {
+                                    continue;
+                                }
+                            }
                             match key.code {
                             KeyCode::Char('q') => break Ok(()),
                             KeyCode::Char('c') if key.modifiers.contains(crossterm::event::KeyModifiers::CONTROL) => break Ok(()),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard input handling on Windows to eliminate duplicate key event processing, improving input responsiveness and providing a more seamless user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->