### PR TITLE
fix: Scroll the services view correctly after clearing dead services

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -235,10 +235,10 @@ impl AppState {
 
             // Adjust selection indices - if user was at the end, keep them at the end
             if new_filtered_len > 0 {
-                // If we were at or near the end (within 2 items), position at the new end
-                if self.selected_service >= initial_filtered_len.saturating_sub(2)
-                    || self.selected_service >= new_filtered_len
-                {
+                let was_near_end = initial_filtered_len > 0
+                    && (self.selected_service >= initial_filtered_len.saturating_sub(2)
+                        || self.selected_service >= new_filtered_len);
+                if was_near_end {
                     self.selected_service = new_filtered_len.saturating_sub(1);
                 } else {
                     // Otherwise, keep the same position but cap it to the new maximum


### PR DESCRIPTION
Closes #58 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list navigation and scrolling when items are removed: selection now preserves relative position, snaps to the new end if near the bottom, resets when the list becomes empty, and keeps the selected item visible by adjusting scroll offset as needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->