### PR TITLE
feat: Add page navigation for service types

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -518,6 +518,9 @@ impl AppState {
     }
 
     fn handle_normal_mode_key(&mut self, key: KeyEvent) -> bool {
+        // Debug: Log all key events to see what's happening
+        eprintln!("DEBUG: Key event: {:?}, modifiers: {:?}", key.code, key.modifiers);
+
         match key.code {
             // Quit actions
             KeyCode::Char('q') => {
@@ -608,6 +611,7 @@ impl AppState {
                 true
             }
 
+<<<<<<< HEAD
             // Page navigation - check modifiers in order of specificity
             // Shift+PageUp/PageDown for service type page navigation (more standard desktop shortcuts)
             KeyCode::PageUp => {
@@ -641,15 +645,33 @@ impl AppState {
                 } else {
                     self.navigate_services_page_down();
                 }
-                true
-            }
-
-            KeyCode::PageDown
+=======
+            // Page navigation - check Ctrl modifiers first
+            KeyCode::PageUp => {
+                eprintln!("DEBUG: PageUp key received! modifiers: {:?}", key.modifiers);
                 if key
                     .modifiers
                     .contains(crossterm::event::KeyModifiers::CONTROL) =>
             {
-                self.navigate_service_types_page_down();
+                self.navigate_service_types_page_up();
+            } else {
+                self.navigate_services_page_up();
+            }
+                true
+            }
+>>>>>>> 6055cc0fff735758dae65041c7e2f42636b80ab4
+                true
+            }
+
+            KeyCode::PageDown => {
+                if key
+                    .modifiers
+                    .contains(crossterm::event::KeyModifiers::CONTROL)
+                {
+                    self.navigate_service_types_page_down();
+                } else {
+                    self.navigate_services_page_down();
+                }
                 true
             }
 
@@ -671,13 +693,18 @@ impl AppState {
                 true
             }
 
+<<<<<<< HEAD
             // Character-based page navigation for services
+=======
+            // Regular page navigation for services (character alternatives)
+>>>>>>> 6055cc0fff735758dae65041c7e2f42636b80ab4
             KeyCode::Char('b') => {
                 self.navigate_services_page_up();
                 true
             }
 
             KeyCode::Char('f') | KeyCode::Char(' ') => {
+<<<<<<< HEAD
                 self.navigate_services_page_down();
                 true
             }
@@ -687,6 +714,8 @@ impl AppState {
                     .modifiers
                     .contains(crossterm::event::KeyModifiers::CONTROL) =>
             {
+=======
+>>>>>>> 6055cc0fff735758dae65041c7e2f42636b80ab4
                 self.navigate_services_page_down();
                 true
             }


### PR DESCRIPTION
## Summary
- Added page navigation functions for service types: page_up, page_down, to_first, to_last
- Added keyboard shortcuts with Ctrl modifier for service type navigation:
  - Ctrl+PageUp/PageDown for page scrolling
  - Ctrl+Home/End for jump to first/last service type
- Updated help text to include the new navigation controls
- Added comprehensive tests covering edge cases and different scenarios
- Maintained consistency with existing service navigation patterns

## Details
This addresses the issue where the service type list becomes crowded with many service types, making navigation difficult. The implementation follows the same patterns as the existing service list navigation, providing a consistent user experience.

## Controls Added
- `Ctrl+PageUp/PageDown` - Scroll service types by page
- `Ctrl+Home/End` - Jump to first/last service type

## Testing
Added 5 new test functions covering:
- Basic page navigation functionality
- Edge cases (empty list, single item)
- Boundary conditions
- Scroll offset behavior
- Small viewport scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl+PageUp/PageDown for page-step navigation through service types.
  * Ctrl+Home/Ctrl+End to jump to first/last service type.
  * Ctrl-based navigation integrated into normal-mode key handling.

* **Tests**
  * Added tests covering page navigation, offsets, boundaries, empty/single-type sets, and interactions with existing navigation.

* **Documentation**
  * Help text updated to document new keyboard navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->