### PR TITLE
chore: Remove version extraction step from release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,17 +26,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 📝 Extract latest version from Cargo.toml
-        id: get-version
-        run: |
-          CURRENT_VERSION=$(grep '^version =' Cargo.toml | head -n1 | sed -E 's/version = "([^"]+)"/\1/')
-          echo "current-version=v$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-
       - name: 🗒️ Draft a new release
         uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6.2.0
         with:
           prerelease: true
           latest: false
-          version: ${{ steps.get-version.outputs.current-version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removed the step to extract the latest version from Cargo.toml in the release drafter workflow, so changes of #107 have an effect 