### PR TITLE
chore: Remove Release Drafter trigger from bump version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -89,4 +89,3 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           ${RULESET} \
           --input -
-  


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic workflow trigger from the version bump process. The release workflow will no longer run automatically after version updates on the main branch and may require manual invocation going forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->