### PR TITLE
fix: Correctly format service types with subtypes in display

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -2326,8 +2326,7 @@ fn format_service_type_for_display(service_type: &str) -> String {
         .trim_start_matches('_')
         .trim_end_matches(".local.")
         .trim_end_matches(".")
-        .replace("._tcp", ".tcp")
-        .replace("._udp", ".udp")
+        .replace("._", ".")
 }
 
 fn create_service_list_item_style(
@@ -4387,12 +4386,12 @@ mod tests {
             "printer.tcp"
         );
         assert_eq!(
-            format_service_type_for_display("_airplay._sub._raop._tcp."),
-            "airplay._sub._raop.tcp"
+            format_service_type_for_display("airplay._sub._raop._tcp."),
+            "airplay.sub.raop.tcp"
         );
         assert_eq!(
-            format_service_type_for_display("_invalid._sub._service._protocol."),
-            "invalid._sub._service._protocol"
+            format_service_type_for_display("invalid._sub._service._protocol."),
+            "invalid.sub.service.protocol"
         );
         assert_eq!(
             format_service_type_for_display("_http._tcp.local."),


### PR DESCRIPTION
## Summary
- Fixed `format_service_type_for_display` to correctly handle service types with subtypes
- Updated the function to replace all `._` patterns with `.` instead of only handling specific protocol patterns
- Updated test cases to reflect the correct expected behavior for subtypes

## Changes
- Modified `format_service_type_for_display` in `src/tui_app.rs` to use `.replace("._", ".")` instead of separate replacements for `._tcp` and `._udp`
- Updated test cases to match the new correct behavior:
  - `airplay._sub._raop._tcp.` now correctly formats to `airplay.sub.raop.tcp`
  - `invalid._sub._service._protocol.` now correctly formats to `invalid.sub.service.protocol`

## Testing
- All existing tests pass
- The specific test for `format_service_type_for_display` passes with the updated expectations
- Code follows project style guidelines (cargo fmt and cargo clippy pass)

This fix ensures that service types with subtypes are displayed correctly in the TUI interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified service type display formatting to consistently normalize all protocol separators using a generalized approach. Service types now display with standardized formatting (e.g., "_airplay._sub._raop._tcp." becomes "airplay.sub.raop.tcp") across all service discovery types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->