### PR TITLE
Fix details scroll reset when navigating services with only one item

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -1276,6 +1276,7 @@ impl AppState {
     }
 
     fn navigate_services_up(&mut self) {
+        let old_selected_service = self.selected_service;
         let filtered_len = {
             let filtered = self.get_filtered_services();
             filtered.len()
@@ -1285,10 +1286,14 @@ impl AppState {
             &mut self.services_scroll,
             filtered_len,
         );
-        self.details_scroll.reset(); // Reset details scroll when navigating
+        // Only reset details scroll when selection actually changes
+        if old_selected_service != self.selected_service {
+            self.details_scroll.reset();
+        }
     }
 
     fn navigate_services_down(&mut self) {
+        let old_selected_service = self.selected_service;
         let filtered_len = {
             let filtered = self.get_filtered_services();
             filtered.len()
@@ -1298,7 +1303,10 @@ impl AppState {
             &mut self.services_scroll,
             filtered_len,
         );
-        self.details_scroll.reset(); // Reset details scroll when navigating
+        // Only reset details scroll when selection actually changes
+        if old_selected_service != self.selected_service {
+            self.details_scroll.reset();
+        }
     }
 
     fn navigate_service_types_up(&mut self) {
@@ -1426,6 +1434,7 @@ impl AppState {
     }
 
     fn navigate_services_page_up(&mut self) {
+        let old_selected_service = self.selected_service;
         let filtered_len = {
             let filtered = self.get_filtered_services();
             filtered.len()
@@ -1435,10 +1444,14 @@ impl AppState {
             &mut self.services_scroll,
             filtered_len,
         );
-        self.details_scroll.reset(); // Reset details scroll when navigating
+        // Only reset details scroll when selection actually changes
+        if old_selected_service != self.selected_service {
+            self.details_scroll.reset();
+        }
     }
 
     fn navigate_services_page_down(&mut self) {
+        let old_selected_service = self.selected_service;
         let filtered_len = {
             let filtered = self.get_filtered_services();
             filtered.len()
@@ -1448,15 +1461,23 @@ impl AppState {
             &mut self.services_scroll,
             filtered_len,
         );
-        self.details_scroll.reset(); // Reset details scroll when navigating
+        // Only reset details scroll when selection actually changes
+        if old_selected_service != self.selected_service {
+            self.details_scroll.reset();
+        }
     }
 
     fn navigate_services_to_first(&mut self) {
+        let old_selected_service = self.selected_service;
         navigate_list_to_first(&mut self.selected_service, &mut self.services_scroll);
-        self.details_scroll.reset(); // Reset details scroll when navigating
+        // Only reset details scroll when selection actually changes
+        if old_selected_service != self.selected_service {
+            self.details_scroll.reset();
+        }
     }
 
     fn navigate_services_to_last(&mut self) {
+        let old_selected_service = self.selected_service;
         let filtered_len = {
             let filtered = self.get_filtered_services();
             filtered.len()
@@ -1466,7 +1487,10 @@ impl AppState {
             &mut self.services_scroll,
             filtered_len,
         );
-        self.details_scroll.reset(); // Reset details scroll when navigating
+        // Only reset details scroll when selection actually changes
+        if old_selected_service != self.selected_service {
+            self.details_scroll.reset();
+        }
     }
 
     // Filter methods
@@ -2959,6 +2983,140 @@ mod tests {
             state.service_types.len(),
             expected,
             "Service type count mismatch"
+        );
+    }
+
+    // Tests for details scroll fix
+    /// Test that details scroll is not reset when navigating with only one service
+    #[test]
+    fn test_details_scroll_not_reset_with_single_service() {
+        let mut state = setup_test_state_with_services(vec![create_test_service(
+            "test1",
+            "_http._tcp.local.",
+            8080,
+        )]);
+
+        // Set initial scroll position
+        state.details_scroll.offset = 5;
+        state.details_scroll.visible_items = 10;
+
+        // Try to navigate up (should not change selection)
+        let old_details_offset = state.details_scroll.offset;
+        state.navigate_services_up();
+        assert_eq!(
+            state.details_scroll.offset, old_details_offset,
+            "Details scroll should not reset when navigating up with single service"
+        );
+
+        // Try to navigate down (should not change selection)
+        let old_details_offset = state.details_scroll.offset;
+        state.navigate_services_down();
+        assert_eq!(
+            state.details_scroll.offset, old_details_offset,
+            "Details scroll should not reset when navigating down with single service"
+        );
+    }
+
+    /// Test that details scroll is reset when actually changing services
+    #[test]
+    fn test_details_scroll_reset_when_changing_services() {
+        let mut state = setup_test_state_with_services(vec![
+            create_test_service("test1", "_http._tcp.local.", 8080),
+            create_test_service("test2", "_http._tcp.local.", 8081),
+        ]);
+
+        // Set initial scroll position
+        state.details_scroll.offset = 5;
+        state.details_scroll.visible_items = 10;
+
+        // Navigate down (should change selection and reset scroll)
+        state.navigate_services_down();
+        assert_eq!(state.selected_service, 1, "Should select second service");
+        assert_eq!(
+            state.details_scroll.offset, 0,
+            "Details scroll should reset when changing services"
+        );
+    }
+
+    /// Test that page navigation respects the same logic
+    #[test]
+    fn test_details_scroll_page_navigation_with_single_service() {
+        let mut state = setup_test_state_with_services(vec![create_test_service(
+            "test1",
+            "_http._tcp.local.",
+            8080,
+        )]);
+
+        // Set initial scroll position
+        state.details_scroll.offset = 5;
+        state.details_scroll.visible_items = 10;
+
+        // Try page up (should not change selection)
+        let old_details_offset = state.details_scroll.offset;
+        state.navigate_services_page_up();
+        assert_eq!(
+            state.details_scroll.offset, old_details_offset,
+            "Details scroll should not reset on page up with single service"
+        );
+
+        // Try page down (should not change selection)
+        let old_details_offset = state.details_scroll.offset;
+        state.navigate_services_page_down();
+        assert_eq!(
+            state.details_scroll.offset, old_details_offset,
+            "Details scroll should not reset on page down with single service"
+        );
+    }
+
+    /// Test that home/end navigation respects the same logic
+    #[test]
+    fn test_details_scroll_home_end_with_single_service() {
+        let mut state = setup_test_state_with_services(vec![create_test_service(
+            "test1",
+            "_http._tcp.local.",
+            8080,
+        )]);
+
+        // Set initial scroll position
+        state.details_scroll.offset = 5;
+        state.details_scroll.visible_items = 10;
+
+        // Try navigate to first (should not change selection)
+        let old_details_offset = state.details_scroll.offset;
+        state.navigate_services_to_first();
+        assert_eq!(
+            state.details_scroll.offset, old_details_offset,
+            "Details scroll should not reset on navigate to first with single service"
+        );
+
+        // Try navigate to last (should not change selection)
+        let old_details_offset = state.details_scroll.offset;
+        state.navigate_services_to_last();
+        assert_eq!(
+            state.details_scroll.offset, old_details_offset,
+            "Details scroll should not reset on navigate to last with single service"
+        );
+    }
+
+    /// Test that navigation resets scroll when there are multiple services
+    #[test]
+    fn test_details_scroll_reset_with_multiple_services() {
+        let mut state = setup_test_state_with_services(vec![
+            create_test_service("test1", "_http._tcp.local.", 8080),
+            create_test_service("test2", "_http._tcp.local.", 8081),
+            create_test_service("test3", "_http._tcp.local.", 8082),
+        ]);
+
+        // Set initial scroll position
+        state.details_scroll.offset = 5;
+        state.details_scroll.visible_items = 10;
+
+        // Navigate to last service
+        state.navigate_services_to_last();
+        assert_eq!(state.selected_service, 2, "Should select third service");
+        assert_eq!(
+            state.details_scroll.offset, 0,
+            "Details scroll should reset when navigating to last service"
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes the confusing UX where the details view scrolls to the top when navigating services, even when there's only one service displayed and the selection doesn't actually change.

## Changes Made
- Modified 6 navigation methods to only reset details scroll when service selection actually changes
- Added comprehensive test coverage (5 new tests) to verify the fix
- Preserves existing behavior for multi-service scenarios

## Navigation Methods Updated
- `navigate_services_up()` and `navigate_services_down()`
- `navigate_services_page_up()` and `navigate_services_page_down()`
- `navigate_services_to_first()` and `navigate_services_to_last()`

## Test Coverage
- Single service scenarios: scroll position preserved
- Multi-service scenarios: scroll still resets when changing services
- All navigation types: up/down, page up/down, home/end

## Technical Details
The fix captures the old `selected_service` value before navigation and only calls `details_scroll.reset()` when `old_selected_service != self.selected_service`, ensuring the scroll position is preserved when navigation doesn't change the selected service.

Resolves the issue where users would lose their scroll position in the details view when using navigation keys in single-service scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Service detail scroll position now preserves when navigating between items while staying on the same service, instead of always resetting on navigation actions. Scroll only resets when switching to a different service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->