### PR TITLE
fix: release-drafter configuration to create pre-releases instead of drafts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,8 @@
 # Copyright 2026 hrzlgnm
 # SPDX-License-Identifier: MIT-0
 
+prerelease: true
+
 change-template: "- $TITLE @$AUTHOR #$NUMBER"
 sort-direction: ascending
 


### PR DESCRIPTION
## Summary
- Add draft: false and prerelease: true to release-drafter.yml configuration
- Fixes issue where workflow was creating draft releases instead of pre-releases
- Ensures release-drafter creates pre-releases by default

## Root Cause
Release-drafter defaults to creating drafts unless explicitly configured otherwise. The workflow parameters (prerelease: true, draft: false) were being overridden by the default configuration in .github/release-drafter.yml.

## Solution
Added top-level configuration to release-drafter.yml:
- prerelease: true

This ensures the unified release workflow creates immediate pre-releases as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to enable prerelease releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->