### PR TITLE
fix: Add prereleased trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
   release:
     types:
       - published
+      - prereleased
 
 jobs:
   source:


### PR DESCRIPTION
- Add prereleased event type to trigger on pre-release publishing
- Ensures publish workflow runs when unified release creates pre-release
- Complements existing published event type for regular releases