### PR TITLE
fix: correct help popup color description for sort field

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -2236,7 +2236,7 @@ fn generate_help_content() -> Vec<Line<'static>> {
         Line::from("   S                 - Cycle sort field backward"),
         Line::from("   o                 - Toggle sort direction (↑/↓)"),
         Line::from(" "),
-        Line::from("   Sort field highlighted in yellow, direction in cyan"),
+        Line::from("   Sort field highlighted in white (underlined), direction in cyan (bold)"),
         Line::from(" "),
         Line::from(" Quick Filter:"),
         Line::from("   /                 - Start typing to filter services"),


### PR DESCRIPTION
## Summary
- Fixed mismatched color description in help popup for sort field highlighting
- Updated help text to accurately reflect actual UI colors: white (underlined) for sort field, cyan (bold) for direction
- Ensures documentation matches visual appearance of sorting indicators

## Changes
- Modified `generate_help_content()` function in `src/tui_app.rs`
- Changed description from "Sort field highlighted in yellow, direction in cyan" to "Sort field highlighted in white (underlined), direction in cyan (bold)"

## Testing
- All existing tests pass (183/183)
- Code formatting and clippy checks pass
- Manual verification confirms help text now matches actual UI colors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text to more accurately describe how sort field and direction indicators are visually highlighted in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->