### PR TITLE
feat: implement 2-second service debouncing for flapping services

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -24,10 +24,6 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::RwLock;
 
-// Type alias for HashMap that can store both String and &str keys
-// Type alias for HashMap that stores String keys (from service fullname) to u64 timestamps
-type PendingRemovalsMap = HashMap<String, u64>;
-
 const STATUS_OK: Color = Color::Blue;
 const STATUS_ERROR: Color = Color::Yellow;
 
@@ -477,7 +473,7 @@ struct AppState {
     terminal_area: ratatui::layout::Rect,
     user_service_types: HashSet<String>,
     status_message: Arc<tokio::sync::Mutex<String>>,
-    pending_removals: PendingRemovalsMap,
+    pending_removals: HashMap<String, u64>,
     cleanup_task_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
@@ -1826,10 +1822,12 @@ fn current_timestamp_micros() -> u64 {
 }
 
 async fn start_cleanup_task_for_state(state: Arc<RwLock<AppState>>) {
-    // Check if cleanup task is already running for this service type
-    let state_guard = state.read().await;
-    if state_guard.cleanup_task_handle.is_some() {
-        return; // Task already running
+    // Check if cleanup task is already running
+    {
+        let state_guard = state.read().await;
+        if state_guard.cleanup_task_handle.is_some() {
+            return; // Task already running
+        }
     }
 
     let state_clone = Arc::clone(&state);
@@ -1889,30 +1887,19 @@ fn start_browsing_service_type(
 
         while let Ok(service_event) = service_receiver.recv_async().await {
             match service_event {
-ServiceEvent::ServiceRemoved(_service_type, fullname) => {
+                ServiceEvent::ServiceRemoved(_service_type, fullname) => {
                     let mut state = state_inner.write().await;
                     let was_empty_before = state.pending_removals.is_empty();
                     state.schedule_service_removal(&fullname);
                     // Start cleanup task if this is the first pending removal
                     if was_empty_before {
-                        // Drop the write lock before calling async function to avoid deadlock
-                        drop(state);
                         start_cleanup_task_for_state(state_inner.clone()).await;
                     }
-                }
                 }
                 ServiceEvent::ServiceResolved(resolved_service) => {
                     let entry = ServiceEntry::from(*resolved_service);
                     let fullname = entry.fullname.clone();
                     let mut state = state_inner.write().await;
-
-                    // Always use the resolved service entry to ensure metadata is up-to-date
-                    // This handles both normal updates and flapping cases correctly
-                    state.add_or_update_service(entry);
-
-                    state.invalidate_cache_and_validate();
-                    let _ = notification_sender_inner.send(Notification::ServiceChanged);
-                }
 
                     // Check if this was a pending removal (flapping service)
                     let was_flapping = state.cancel_pending_removal(&fullname);
@@ -7587,15 +7574,18 @@ mod tests {
     fn test_flapping_service_scenario() {
         let mut state = AppState::new(HashSet::new());
 
-        // Add a service with correct name
+        // Add a service
         let service = create_test_service("test", "_http._tcp.local.", 8080);
-        let fullname = service.fullname.clone(); // Use actual service fullname
         state.services.push(service);
-        state.schedule_service_removal(&fullname.clone());
-        assert!(state.pending_removals.contains_key(&fullname));
+
+        let fullname = "test-service._http._tcp.local.";
+
+        // Simulate service removal
+        state.schedule_service_removal(fullname);
+        assert!(state.pending_removals.contains_key(fullname));
 
         // Simulate service coming back quickly (flapping)
-        let was_flapping = state.cancel_pending_removal(&fullname);
+        let was_flapping = state.cancel_pending_removal(fullname);
         assert!(was_flapping);
         assert_eq!(state.metrics.get("flapping_services_detected"), Some(&1));
 


### PR DESCRIPTION
- Add pending_removals HashMap to track scheduled removals
- Implement background cleanup task with 500ms intervals
- Debounce services that are removed and resolved within 2 seconds
- Add metrics for flapping detection and UI update prevention
- Add comprehensive unit tests for debouncing scenarios
- Preserve all existing functionality while eliminating UI flickering

Closes issue where mDNS responders not sending unsolicited defensive responses shortly before TTL expires causes service flapping in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-service-type debounced offline marking with a background cleanup task to delay and consolidate offline transitions.

* **Bug Fixes**
  * Reduces rapid online/offline flapping and race conditions by honoring pending removals and canceling removals when services reappear.

* **Tests**
  * Comprehensive tests for scheduling, cancellation, expirations, flapping, multiple removals, and integration with metrics.

* **Metrics**
  * Tracks pending debounced removals and updates cleanup/status metrics during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->