### PR TITLE
docs: Add link to desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/hrzlgnm/mdns-tui-browser/ci.yml)](https://github.com/hrzlgnm/mdns-tui-browser/actions)
 # mDNS TUI Browser
 
-A terminal-based mDNS service browser built with Rust, using `ratatui` for the TUI interface.
-For a alternative running as a desktop app, check out [mDNS-Browser](https://github.com/hrzlgnm/mdns-browser)
+A terminal-based mDNS service browser built with Rust, using `ratatui` for the TUI interface. For an alternative running as a desktop app, check out [mDNS-Browser](https://github.com/hrzlgnm/mdns-browser).
 
 ## Features
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README opening to include a brief inline reference and link to an alternative desktop application option; no functional or behavioral changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->