### PR TITLE
feat: add --interfaces CLI argument for interface selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
  "clap",
  "crossterm",
  "flume 0.12.0",
+ "if-addrs",
  "mdns-sd",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+if-addrs = "0.14"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ mdns-tui-browser -s http -s ssh
 
 # Browse without debouncing (for debugging flapping services)
 mdns-tui-browser --no-debounce
+
+# Use specific network interfaces
+mdns-tui-browser -i en0
+mdns-tui-browser --interfaces en0,eth0
 ```
 
 #### Service Types Argument (`--service-types/-s`)
@@ -238,6 +242,7 @@ The application is built with:
 - **chrono** - Date and time handling for local timestamp display
 - **serde** - Serialization framework for JSON export
 - **serde_json** - JSON serialization support
+- **if-addrs** - Network interface enumeration
 
 ### Safety Policy
 
@@ -335,7 +340,7 @@ This ensures that every release binary can be independently verified for securit
 - [x] Export capabilities
 - [x] Service filtering and search
 - [x] Custom service type browsing
-- [ ] Network interface selection
+- [x] Network interface selection
 
 ## License
 

--- a/mdns-tui-browser.1
+++ b/mdns-tui-browser.1
@@ -1,4 +1,4 @@
-.TH mdns-tui-browser 1 "2026-02-12" "mdns-tui-browser" "User Commands"
+.TH mdns-tui-browser 1 "2026-02-13" "mdns-tui-browser" "User Commands"
 
 .SH NAME
 mdns-tui-browser \- terminal-based mDNS service browser
@@ -24,6 +24,10 @@ Auto-completes (_)service, (_)sub, .(_)[tc|ud]p and .local. suffix
 .TP
 .B \-\-no-debounce
 Disable automatic debouncing of flapping services for debugging
+.TP
+.B \-i, \-\-interfaces \fIINTERFACES\fR
+Network interfaces to use for mDNS discovery (e.g., en0, eth0)
+Can be specified multiple times or comma-separated
 
 .SH SERVICE TYPES
 The \fB\-\-service-types\fR argument supports various formats:
@@ -186,6 +190,14 @@ Browse with shortened service types, specified multiple times:
 Browse without debouncing (for debugging flapping services):
 .br
 .B mdns-tui-browser \-\-no-debounce
+.IP \(bu
+Browse using a specific network interface:
+.br
+.B mdns-tui-browser \-i eth0
+.IP \(bu
+Browse using multiple network interfaces:
+.br
+.B mdns-tui-browser \-\-interfaces en0,eth0
 .RE
 
 .SH AUTHOR

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,10 @@
 
 mod tui_app;
 
+use std::collections::HashSet;
+
 use clap::Parser;
+use if_addrs::get_if_addrs;
 
 #[derive(Parser)]
 #[command(
@@ -28,6 +31,15 @@ struct Cli {
         help = "Disable automatic debouncing of flapping services for debugging"
     )]
     no_debounce: bool,
+
+    /// Network interfaces to use for mDNS discovery
+    #[arg(
+        long,
+        short,
+        value_delimiter = ',',
+        help = "Network interfaces to use for mDNS discovery (e.g., en0, eth0)"
+    )]
+    interfaces: Option<Vec<String>>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -41,9 +53,42 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|service_type| tui_app::normalize_service_type(&service_type))
         .collect();
 
+    // Validate interfaces before starting
+    let (interfaces, available_interfaces) = match cli.interfaces {
+        Some(ifs) => {
+            let available: HashSet<String> = get_if_addrs()
+                .map_err(|e| format!("Failed to get network interfaces: {}", e))?
+                .iter()
+                .map(|i| i.name.clone())
+                .collect();
+
+            let mut sorted: Vec<_> = available.iter().collect();
+            sorted.sort();
+
+            for interface in &ifs {
+                if !available.contains(interface) {
+                    return Err(format!(
+                        "Interface '{}' not found. Available interfaces: {}",
+                        interface,
+                        sorted
+                            .iter()
+                            .map(|s| s.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                    .into());
+                }
+            }
+            (Some(ifs), Some(available.into_iter().collect::<Vec<_>>()))
+        }
+        None => (None, None),
+    };
+
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(tui_app::run_tui(
         user_requested_service_types,
         cli.no_debounce,
+        interfaces,
+        available_interfaces,
     ))
 }

--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -2947,9 +2947,44 @@ fn create_service_details_text(service: &ServiceEntry) -> Vec<Line<'static>> {
     lines
 }
 
+/// Runs the TUI application for mDNS service browsing.
+///
+/// # Arguments
+/// * `user_service_types` - Service types to browse for
+/// * `no_debounce` - Whether to disable debouncing of flapping services
+/// * `interfaces` - Optional list of network interface names to bind to.
+///   If `Some`, only the specified interfaces will be used.
+///   If `None`, all available interfaces will be used (default behavior).
+///   The expected string format is the interface name (e.g., "eth0", "en0").
+///   An empty vector `Some(vec![])` will result in no interfaces being used.
+/// * `available_interfaces` - List of all available network interface names.
+///   Used to disable all interfaces before enabling the requested ones.
+///
+/// # Example
+/// ```no_run
+/// use std::collections::HashSet;
+///
+/// async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+///     let service_types = HashSet::new();
+///
+///     // Use default interfaces (all available)
+///     run_tui(service_types.clone(), false, None, None).await;
+///
+///     // Use specific interfaces
+///     run_tui(
+///         service_types,
+///         false,
+///         Some(vec!["eth0".into()]),
+///         Some(vec!["eth0".into(), "lo".into()]),
+///     )
+///     .await
+/// }
+/// ```
 pub async fn run_tui(
     user_service_types: HashSet<String>,
     no_debounce: bool,
+    interfaces: Option<Vec<String>>,
+    available_interfaces: Option<Vec<String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Setup terminal for full TUI
     enable_raw_mode()?;
@@ -2959,6 +2994,25 @@ pub async fn run_tui(
     let mut terminal = Terminal::new(backend)?;
 
     let mdns = ServiceDaemon::new()?;
+
+    if let Some(ifs) = interfaces {
+        let available = available_interfaces.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Available interfaces required when --interfaces is set",
+            )
+        })?;
+
+        for interface in &available {
+            mdns.disable_interface(interface)
+                .map_err(|e| format!("Failed to disable interface '{}': {}", interface, e))?;
+        }
+
+        for interface in &ifs {
+            mdns.enable_interface(interface)
+                .map_err(|e| format!("Failed to enable interface '{}': {}", interface, e))?;
+        }
+    }
 
     // Initialize app state
     let state = Arc::new(RwLock::new(AppState::new(user_service_types, no_debounce)));


### PR DESCRIPTION
## Summary

- Add `-i` / `--interfaces` CLI argument to specify network interfaces for mDNS discovery
- Uses `ServiceDaemon::enable_interface()` to filter to only the specified interfaces
- If interfaces are provided, only those interfaces will be used; otherwise all available interfaces are used
- Returns an error and exits if an invalid interface name is provided

## Usage

```bash
# Single interface
mdns-tui-browser -i en0

# Multiple interfaces (comma-separated)
mdns-tui-browser --interfaces en0,eth0

# Multiple flags
mdns-tui-browser -i en0 -i eth0

# Combined with service types
mdns-tui-browser -i en0 --service-types "_http._tcp.local."
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select network interfaces for mDNS discovery via CLI (-i, --interfaces); accepts comma-separated or repeated values. Startup validates selections and applies them, returning a clear error listing available interfaces if invalid.

* **Documentation**
  * README and man page updated with the new option, usage and quick-filter examples, a note about network-interface enumeration, and refreshed man page date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->