### PR TITLE
feat: add --load-state option to load and inspect state from JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ mdns-tui-browser --interfaces en0,eth0
 # Disable IPv4 or IPv6 mDNS discovery
 mdns-tui-browser --no-ipv4
 mdns-tui-browser --no-ipv6
+
+# Load state from a JSON file (view-only mode, no browsing)
+mdns-tui-browser --load-state state-dump.json
+mdns-tui-browser -l state-dump.json
 ```
 
 #### Service Types Argument (`--service-types/-s`)
@@ -105,7 +109,7 @@ Service types to browse for (e.g., http, _http._tcp, printer). Auto-completes `(
 
 ## JSON State Dump
 
-The application can export the complete current state to a JSON file for debugging and analysis purposes.
+The application can export the complete current state to a JSON file for debugging and analysis purposes, and can also load a previously exported state file for inspection.
 
 ### Usage
 
@@ -114,6 +118,15 @@ Press <kbd>Ctrl</kbd>+<kbd>J</kbd> in the TUI to trigger a state dump. The file 
 ```text
 20260207T120102.089898-state-dump.json
 ```
+
+To load a previously exported state file for inspection (view-only mode, no browsing):
+
+```bash
+mdns-tui-browser --load-state state-dump.json
+mdns-tui-browser -l state-dump.json
+```
+
+When loading a state file, no mDNS browsing is performed. The border color changes to a darker color to indicate view-only mode.
 
 ### JSON Structure
 

--- a/mdns-tui-browser.1
+++ b/mdns-tui-browser.1
@@ -1,4 +1,4 @@
-.TH mdns-tui-browser 1 "2026-02-14" "mdns-tui-browser" "User Commands"
+.TH mdns-tui-browser 1 "2026-02-17" "mdns-tui-browser" "User Commands"
 
 .SH NAME
 mdns-tui-browser \- terminal-based mDNS service browser
@@ -34,6 +34,9 @@ Disable IPv4 mDNS discovery
 .TP
 .B \-\-no-ipv6
 Disable IPv6 mDNS discovery
+.TP
+.B \-l, \-\-load-state \fIFILE\fR
+Load state from a JSON file for inspection (view-only mode, no browsing)
 
 .SH SERVICE TYPES
 The \fB\-\-service-types\fR argument supports various formats:
@@ -110,6 +113,8 @@ Ctrl+J                 - Dump current state to JSON file
 ?                      - Toggle help popup
 .br
 q or Ctrl+c            - Quit the application
+.PP
+\fBNote:\fR When loading a state file with \fB\-\-load-state\fR, the application runs in view-only mode (no browsing). The border color changes to a darker color to indicate this mode.
 
 .SH QUICK FILTER
 The quickfilter feature allows searching across all service fields using text patterns and special keywords.
@@ -212,6 +217,10 @@ Disable IPv4 mDNS discovery:
 Disable IPv6 mDNS discovery:
 .br
 .B mdns-tui-browser \-\-no-ipv6
+.IP \(bu
+Load state from a JSON file (view-only mode):
+.br
+.B mdns-tui-browser \-\-load-state state-dump.json
 .RE
 
 .SH AUTHOR

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod tui_app;
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 
 use clap::Parser;
 use if_addrs::get_if_addrs;
@@ -55,13 +56,13 @@ struct Cli {
         short,
         help = "Load state from a JSON file for inspection (view-only mode, no browsing)"
     )]
-    load_state: Option<String>,
+    load_state: Option<PathBuf>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    if cli.no_ipv4 && cli.no_ipv6 {
+    if cli.load_state.is_none() && cli.no_ipv4 && cli.no_ipv6 {
         return Err("Cannot disable both IPv4 and IPv6. At least one must be enabled.".into());
     }
 
@@ -107,14 +108,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let disable_ipv4 = cli.no_ipv4;
     let disable_ipv6 = cli.no_ipv6;
 
-    let loaded_state: Option<String> = if let Some(path) = cli.load_state {
-        Some(
+    let loaded_state: Option<String> = cli
+        .load_state
+        .map(|path| {
             std::fs::read_to_string(&path)
-                .map_err(|e| format!("Failed to read state file '{}': {}", path, e))?,
-        )
-    } else {
-        None
-    };
+                .map_err(|e| format!("Failed to read state file '{}': {}", path.display(), e))
+        })
+        .transpose()?;
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(tui_app::run_tui(

--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: MIT-0
 #![forbid(unsafe_code)]
 
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
 use crossterm::{
     event::{self, Event, KeyCode, KeyEvent},
     execute,
@@ -16,11 +21,6 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
@@ -53,7 +53,8 @@ fn micros_to_iso_timestamp(micros: u64) -> String {
 fn iso_timestamp_to_micros(timestamp: &str) -> u64 {
     if let Ok(dt) = DateTime::parse_from_rfc3339(timestamp) {
         let duration = dt.signed_duration_since(DateTime::<Utc>::from_timestamp(0, 0).unwrap());
-        return duration.num_microseconds().unwrap_or(0) as u64;
+        let micros = duration.num_microseconds().unwrap_or(0);
+        return if micros < 0 { 0 } else { micros as u64 };
     }
     if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%dT%H:%M:%S%.fZ") {
         let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
@@ -61,7 +62,8 @@ fn iso_timestamp_to_micros(timestamp: &str) -> u64 {
             .and_hms_opt(0, 0, 0)
             .unwrap();
         let duration = dt.signed_duration_since(epoch);
-        return duration.num_microseconds().unwrap_or(0) as u64;
+        let micros = duration.num_microseconds().unwrap_or(0);
+        return if micros < 0 { 0 } else { micros as u64 };
     }
     0
 }
@@ -79,6 +81,7 @@ impl From<&ServiceEntry> for SerializableServiceEntry {
             None
         };
         Self {
+            fullname: entry.fullname.clone(),
             host: entry.host.clone(),
             service_type: entry.service_type.clone(),
             subtype: entry.subtype.clone(),
@@ -123,7 +126,7 @@ impl From<&SerializableServiceEntry> for ServiceEntry {
             .map(|ts| iso_timestamp_to_micros(ts));
 
         Self {
-            fullname: format!("{}.{}", entry.host, entry.service_type),
+            fullname: entry.fullname.clone(),
             host: entry.host.clone(),
             service_type: entry.service_type.clone(),
             subtype: entry.subtype.clone(),
@@ -196,6 +199,7 @@ struct ServiceEntry {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SerializableServiceEntry {
+    fullname: String,
     host: String,
     service_type: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3161,6 +3165,7 @@ fn create_service_details_text(service: &ServiceEntry) -> Vec<Line<'static>> {
 ///   Used to disable all interfaces before enabling the requested ones.
 /// * `disable_ipv4` - Whether to disable IPv4 mDNS discovery
 /// * `disable_ipv6` - Whether to disable IPv6 mDNS discovery
+/// * `loaded_state` - Optional JSON string to load state from file (view-only mode)
 ///
 /// # Example
 /// ```no_run
@@ -3170,7 +3175,7 @@ fn create_service_details_text(service: &ServiceEntry) -> Vec<Line<'static>> {
 ///     let service_types = HashSet::new();
 ///
 ///     // Use default interfaces (all available)
-///     run_tui(service_types.clone(), false, None, None, false, false).await;
+///     run_tui(service_types.clone(), false, None, None, false, false, None).await;
 ///
 ///     // Use specific interfaces
 ///     run_tui(
@@ -3180,6 +3185,7 @@ fn create_service_details_text(service: &ServiceEntry) -> Vec<Line<'static>> {
 ///         Some(vec!["eth0".into(), "lo".into()]),
 ///         false,
 ///         false,
+///         None,
 ///     )
 ///     .await
 /// }
@@ -3193,14 +3199,28 @@ pub async fn run_tui(
     disable_ipv6: bool,
     loaded_state: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if disable_ipv4 && disable_ipv6 {
+        return Err("Cannot disable both IPv4 and IPv6. At least one must be enabled.".into());
+    }
+
+    let is_view_only = loaded_state.is_some();
+
+    // Parse state file before terminal setup to avoid leaving terminal in broken state on error
+    let state_dump: Option<StateDump> = if let Some(json_content) = loaded_state {
+        Some(
+            serde_json::from_str(&json_content)
+                .map_err(|e| format!("Failed to parse state file: {}", e))?,
+        )
+    } else {
+        None
+    };
+
     // Setup terminal for full TUI
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
-
-    let is_view_only = loaded_state.is_some();
 
     let mdns = if is_view_only {
         None
@@ -3252,11 +3272,9 @@ pub async fn run_tui(
     )));
 
     // Load state from file if provided
-    if let Some(json_content) = loaded_state {
-        let state_dump: StateDump = serde_json::from_str(&json_content)
-            .map_err(|e| format!("Failed to parse state file: {}", e))?;
+    if let Some(dump) = state_dump {
         let mut state_write = state.write().await;
-        state_write.load_from_state_dump(state_dump);
+        state_write.load_from_state_dump(dump);
     }
 
     // Create notification channels


### PR DESCRIPTION
## Summary

- Add `--load-state` / `-l` CLI option to load previously dumped state JSON file for inspection
- When loaded, no mDNS browsing is performed - displays only services from the file
- Border color changes to darker (`DarkGray`) to indicate view-only mode
- Text color remains unchanged for readability

### Changes
- Add CLI argument parsing for `--load-state` / `-l`
- Add `Deserialize` to serializable structs for loading state
- Add `loaded_from_file` field to `AppState`
- Add `load_from_state_dump` method to populate state from JSON
- Modify `run_tui` to skip mDNS browsing in view-only mode
- Update UI render functions to use darker border when loaded
- Add test for loading state from JSON

### Usage
```bash
cargo run -- --load-state state-dump.json
# or
cargo run -l state-dump.json
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --load-state (-l) CLI option to load and inspect saved JSON state in view-only mode.
  * View-only mode disables background discovery and updates, letting you browse a static snapshot.
  * UI shows a distinct border style when viewing a loaded state.

* **Bug Fixes**
  * Validation that both IPv4 and IPv6 cannot be disabled only applies in live mode (not when loading a state).

* **Documentation**
  * Updated README and manpage with usage, examples, and behavior notes for load-state.

* **Tests**
  * Added tests validating state dump loading and reconstruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->