### PR TITLE
chore: build for ubuntu-22.40, too

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -120,9 +120,11 @@ jobs:
           # Rename deb to avoid conflicts between ubuntu-latest and ubuntu-22.04
           if [ "${{ matrix.os }}" = "ubuntu-22.04" ]; then
             cd "target/${{ matrix.target }}/debian" || exit 1
-            ORIGINAL_DEB=$(ls *.deb)
-            NEW_NAME="${ORIGINAL_DEB%.deb}-glibc2.35.deb"
-            mv "$ORIGINAL_DEB" "$NEW_NAME"
+            for deb_file in *.deb; do
+              [ -f "$deb_file" ] || continue
+              new_name="${deb_file%.deb}-glibc2.35.deb"
+              mv "$deb_file" "$new_name"
+            done
           fi
 
       - name: 📦 Build archive


### PR DESCRIPTION
For the poor souls on ubuntu-22.04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded build platform support to include Ubuntu 22.04 with glibc-2.35.
  * Enhanced compatibility across Ubuntu-based build environments.
  * Improved support for additional OS and architecture combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->