### PR TITLE
fix: preserve key-only TXT records in service properties

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -424,9 +424,9 @@ impl From<ResolvedService> for ServiceEntry {
                 let mut txt: Vec<String> = resolved_service
                     .get_properties()
                     .iter()
-                    .filter_map(|prop| {
-                        prop.val()
-                            .map(|val| format!("{}={}", prop.key(), String::from_utf8_lossy(val)))
+                    .map(|prop| match prop.val() {
+                        Some(val) => format!("{}={}", prop.key(), String::from_utf8_lossy(val)),
+                        None => prop.key().to_string(),
                     })
                     .collect();
                 txt.sort_by(|a, b| {


### PR DESCRIPTION
## Summary
- Fixes issue #210
- Preserve key-only TXT records in service properties that were previously being dropped
- Changed `filter_map` to `map` with a `match` to handle both key=value and key-only TXT entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of service properties to include those without explicit values in TXT records. The application now displays more complete service information, presenting all available properties instead of omitting those lacking assigned values. This change enhances visibility of service details throughout the interface and may affect how information is sorted and organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->