### PR TITLE
ci: update attest-build-provenance to actions/attest@v4

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: 🔐 Generate provenance attestation
         if: inputs.tagName
-        uses: actions/attest-build-provenance@c5efebd311e9a809e832398ca2b73bb429ff3508
+        uses: actions/attest@v4
         with:
           subject-path: ${{ matrix.os == 'ubuntu-latest' && env.ATTESTATION_SUBJECTS || env.ASSET }}
 


### PR DESCRIPTION
## Summary
- Consolidate actions/attest-build-provenance and actions/attest-sbom into actions/attest@v4
- Use @v4 tag so renovate can maintain digest updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to use the latest provenance attestation implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->