### PR TITLE
fix: update services flapping status after loading a state dump

### DIFF
--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -523,6 +523,9 @@ impl AppState {
 
     fn load_from_state_dump(&mut self, dump: StateDump) {
         self.services = dump.services.iter().map(|s| s.into()).collect();
+        self.services
+            .iter_mut()
+            .for_each(|s| s.update_flapping_status());
         self.service_types = dump.service_types;
         self.metrics = dump.metrics;
         self.filter_query = dump.filters.query;


### PR DESCRIPTION
So the new flapping detection algorithm is also applied on loaded state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Flapping status of services is now properly refreshed when loading a saved state, ensuring accurate service status information immediately upon restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->