### PR TITLE
test: add unit test verifying flapping is recomputed on state load

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -61,7 +61,27 @@ pub struct SerializableServiceEntry {
 fn is_zero_u16(v: &u16) -> bool {
     *v == 0
 }
-fn micros_to_iso_timestamp(micros: u64) -> String {
+/// Converts a timestamp from microseconds since the Unix epoch to an ISO 8601 formatted UTC string.
+///
+/// # Arguments
+/// * `micros` - Number of microseconds since the Unix epoch (1970-01-01T00:00:00Z)
+///
+/// # Returns
+/// An ISO 8601 formatted UTC timestamp string in the format `YYYY-MM-DDTHH:MM:SS.ffffffZ`
+///
+/// # Behavior Notes
+/// - Input is in microseconds since the Unix epoch
+/// - Output is in UTC (no timezone offset applied)
+/// - Sub-microsecond precision is truncated (nanos are derived from subsec_micros * 1000)
+/// - For timestamps before the Unix epoch or other invalid values, returns the Unix epoch as fallback
+///
+/// # Example
+/// ```
+/// let micros = 1_000_000; // 1 second after epoch
+/// let timestamp = crate::models::micros_to_iso_timestamp(micros);
+/// assert_eq!(timestamp, "1970-01-01T00:00:01.000000Z");
+/// ```
+pub fn micros_to_iso_timestamp(micros: u64) -> String {
     let duration = Duration::from_micros(micros);
     let secs = duration.as_secs() as i64;
     let nanos = duration.subsec_micros() * 1000;
@@ -410,6 +430,8 @@ pub fn current_timestamp_micros() -> u64 {
 
 #[cfg(test)]
 pub mod tests {
+    //! Unit tests for the models module.
+
     use super::*;
 
     pub fn create_test_service(name: &str, service_type: &str, port: u16) -> ServiceEntry {
@@ -549,7 +571,22 @@ pub mod tests {
         assert!(service.is_flapping);
     }
 
-    fn micros_from(hours: u32, minutes: u32, seconds: u32) -> u64 {
+    /// Converts hours, minutes, and seconds to microseconds since the Unix epoch.
+    ///
+    /// # Arguments
+    /// * `hours` - Number of hours
+    /// * `minutes` - Number of minutes
+    /// * `seconds` - Number of seconds
+    ///
+    /// # Returns
+    /// The total number of microseconds (hours * 3600 + minutes * 60 + seconds) * 1_000_000
+    ///
+    /// # Example
+    /// ```
+    /// let micros = micros_from(0, 0, 1); // 1 second = 1,000,000 microseconds
+    /// assert_eq!(micros, 1_000_000);
+    /// ```
+    pub fn micros_from(hours: u32, minutes: u32, seconds: u32) -> u64 {
         (hours as u64 * 3600 + minutes as u64 * 60 + seconds as u64) * 1_000_000
     }
 

--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -2721,7 +2721,10 @@ pub async fn run_tui(
 mod tests {
     use super::*;
 
+    use crate::models::SerializableServiceEntry;
+    use crate::models::SerializableServiceSession;
     use crate::models::ServiceSession;
+    use crate::models::micros_to_iso_timestamp;
     use crate::models::tests::{create_test_service, create_test_service_with_sessions};
 
     /// Helper to create AppState for testing
@@ -7090,6 +7093,83 @@ mod tests {
             not_selected_style
                 .add_modifier
                 .contains(Modifier::UNDERLINED)
+        );
+    }
+
+    #[test]
+    fn test_flapping_status_recomputed_after_load() {
+        use crate::models::tests::micros_from;
+
+        let t1 = micros_from(0, 0, 1);
+        let t2 = micros_from(0, 0, 2);
+        let t3 = micros_from(0, 0, 3);
+        let t4 = micros_from(0, 0, 4);
+        let t5 = micros_from(0, 0, 5);
+        let t6 = micros_from(0, 0, 6);
+
+        let session_history = vec![
+            SerializableServiceSession {
+                start_time: Some(micros_to_iso_timestamp(t1)),
+                end_time: Some(micros_to_iso_timestamp(t2)),
+            },
+            SerializableServiceSession {
+                start_time: Some(micros_to_iso_timestamp(t3)),
+                end_time: Some(micros_to_iso_timestamp(t4)),
+            },
+            SerializableServiceSession {
+                start_time: Some(micros_to_iso_timestamp(t5)),
+                end_time: Some(micros_to_iso_timestamp(t6)),
+            },
+        ];
+
+        let serializable_service = SerializableServiceEntry {
+            fullname: "test._http._tcp.local.".to_string(),
+            host: "test.local.".to_string(),
+            service_type: "_http._tcp.local.".to_string(),
+            subtype: None,
+            addresses: vec!["192.168.1.1".to_string()],
+            port: 8080,
+            txt_records: vec![],
+            is_online: true,
+            is_flapping: false,
+            created_at: micros_to_iso_timestamp(t1),
+            updated_at: Some(micros_to_iso_timestamp(t6)),
+            last_online_at: Some(micros_to_iso_timestamp(t6)),
+            last_offline_at: None,
+            session_history,
+        };
+
+        let state_dump = StateDump {
+            metadata: Metadata {
+                dump_timestamp: micros_to_iso_timestamp(t6),
+                application_name: "mdns-tui-browser".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            services: vec![serializable_service],
+            service_types: vec!["_http._tcp.local.".to_string()],
+            metrics: BTreeMap::new(),
+            options: AppOptions {
+                service_types: vec![],
+                disable_ipv4: false,
+                disable_ipv6: false,
+                interfaces: None,
+            },
+            filters: FilterInfo {
+                query: String::new(),
+                active_service_types: None,
+            },
+            sorting: SortInfo {
+                field: SortField::Host,
+                direction: SortDirection::Ascending,
+            },
+        };
+
+        let mut state = create_test_app_state();
+        state.load_from_state_dump(state_dump);
+
+        assert!(
+            state.services[0].is_flapping,
+            "Flapping status should be recomputed after loading state dump"
         );
     }
 }


### PR DESCRIPTION
Closes #232 
## Summary
- Adds `test_flapping_status_recomputed_after_load` unit test in `src/tui_app.rs` that verifies flapping status is recomputed when state is loaded from a dump
- Creates a `SerializableServiceEntry` with 3 short sessions (< 5 seconds each) and `is_flapping: false` in serialized data
- Loads via `load_from_state_dump()` and asserts `is_flapping` is recomputed to `true`
- Exports `micros_to_iso_timestamp` and `micros_from` helpers from `models.rs` for reuse in tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test verifying that flapping status is correctly recomputed after loading a saved state.

* **Refactor**
  * Exposed internal time/formatting utilities to allow reuse and easier extensibility across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->