### PR TITLE
chore: consolidate winget jobs to install komac only once

### DIFF
--- a/.github/workflows/winget-reusable.yml
+++ b/.github/workflows/winget-reusable.yml
@@ -45,11 +45,8 @@ jobs:
         with:
           args: "update hrzlgnm.mdns-tui-browser --version $VERSION --urls $URL --submit --token=${{ secrets.WINGET_TOKEN }}"
 
-  cleanup:
-    name: 🧹 branches
-    runs-on: ubuntu-latest
-    steps:
       - name: 🧹 Cleanup merged branches
+        if: always()
         uses: michidk/run-komac@9b27eadc6e9235c252444a437d246c139da2f57f # v2.1.0
         with:
           args: "cleanup --only-merged --token=${{ secrets.WINGET_TOKEN }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized workflow to ensure cleanup operations complete reliably, regardless of prior task outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->