### PR TITLE
chore: pass winget token via env to komac

### DIFF
--- a/.github/workflows/winget-reusable.yml
+++ b/.github/workflows/winget-reusable.yml
@@ -49,23 +49,22 @@ jobs:
 
       - name: 🆙 sync our fork of winget-pkgs
         env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
-          komac  sync-fork --token="$WINGET_TOKEN"
+          komac  sync-fork
 
       - name: 🆙 winget package
         env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
           komac update hrzlgnm.mdns-tui-browser \
             --version $VERSION \
             --urls $URL \
-            --submit \
-            --token="$WINGET_TOKEN"
+            --submit
 
       - name: 🧹 Cleanup merged branches
         if: always()
         env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
-          komac cleanup --only-merged --token="$WINGET_TOKEN"
+          komac cleanup --only-merged


### PR DESCRIPTION
Closes #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined authentication in automated build workflows to use standard GitHub authentication, improving configuration simplicity and consistency across deployment steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->