### PR TITLE
chore: cache-tools job after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,10 @@ jobs:
     secrets: inherit
 
   cache-tools:
+    needs:
+      - build
     name: "📦 Cache tools"
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: always() && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
     uses: ./.github/workflows/cache-tools-reusable.yml
 
   all-required-green: # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
Ensure cache-tools job runs after build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline workflow dependencies to improve build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->