### PR TITLE
feat: add DMG build support for macOS releases

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -145,6 +145,16 @@ jobs:
             cp "target/${{ matrix.target }}/release/mdns_tui_browser.pdb" "$staging/"
             7z a -tzip "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> "$GITHUB_ENV"
+          elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+            cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$staging/"
+            cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$staging/" || true
+            cp -LR "target/${{ matrix.target }}/release/mdns-tui-browser.dSYM" "$staging/" || true
+            mkdir -p "$staging/man/man1"
+            cp "docs/mdns-tui-browser.1" "$staging/man/man1/"
+            DMG_NAME="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}.dmg"
+            cp "$DMG_NAME" "$staging/"
+            tar czf "$staging.tar.gz" "$staging"
+            echo "ASSET=$staging.tar.gz" >> "$GITHUB_ENV"
           else
             cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$staging/"
             cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$staging/" || true

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -268,6 +268,10 @@ jobs:
                     --app-drop-link 425 150 \
                     "$DMG_NAME" \
                     "$STAGING/"
+          # Self-sign the app bundle (ad-hoc signing)
+          codesign --force --deep --sign - "$STAGING/$APP_NAME"
+          # Sign the DMG
+          codesign --force --sign - "$DMG_NAME"
           echo "DMG_ASSET=$DMG_NAME" >> "$GITHUB_ENV"
 
       - name: 🧮 Compute attestation subjects

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -146,8 +146,13 @@ jobs:
             7z a -tzip "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> "$GITHUB_ENV"
           elif [ "${{ matrix.os }}" = "macos-latest" ]; then
-            # For macOS, tarball is created after DMG build (see below)
-            echo "ASSET=" >> "$GITHUB_ENV"
+            cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$staging/"
+            cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$staging/" || true
+            cp -LR "target/${{ matrix.target }}/release/mdns-tui-browser.dSYM" "$staging/" || true
+            mkdir -p "$staging/man/man1"
+            cp "docs/mdns-tui-browser.1" "$staging/man/man1/"
+            tar czf "$staging.tar.gz" "$staging"
+            echo "ASSET=$staging.tar.gz" >> "$GITHUB_ENV"
           else
             cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$staging/"
             cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$staging/" || true
@@ -263,16 +268,6 @@ jobs:
                     --app-drop-link 425 150 \
                     "$DMG_NAME" \
                     "$STAGING/"
-          # Copy binary, symbols, manpage, and DMG to staging for tarball
-          cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$STAGING/"
-          cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$STAGING/" || true
-          cp -LR "target/${{ matrix.target }}/release/mdns-tui-browser.dSYM" "$STAGING/" || true
-          mkdir -p "$STAGING/man/man1"
-          cp "docs/mdns-tui-browser.1" "$STAGING/man/man1/"
-          cp "$DMG_NAME" "$STAGING/"
-          # Create tarball with all artifacts including DMG
-          tar czf "$STAGING.tar.gz" "$STAGING"
-          echo "ASSET=$STAGING.tar.gz" >> "$GITHUB_ENV"
           echo "DMG_ASSET=$DMG_NAME" >> "$GITHUB_ENV"
 
       - name: 🧮 Compute attestation subjects

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -241,8 +241,8 @@ jobs:
           #!/bin/bash
           SCRIPT=$(mktemp)
           EXE_PATH="$(cd "$(dirname "$0")" && pwd)/mdns-tui-browser"
-          printf -v QUOTED_EXE 'quoted form of "%s"' "$EXE_PATH"
-          printf -v SCRIPT_TEXT 'tell app "Terminal" to do script "%s; exit"\n' "$EXE_PATH"
+          printf -v QUOTED_EXE '%s' "$(osascript -e "quoted form of \"$EXE_PATH\"")"
+          printf -v SCRIPT_TEXT 'tell app "Terminal" to do script %s & "; exit"\n' "$QUOTED_EXE"
           echo "$SCRIPT_TEXT" > "$SCRIPT"
           osascript "$SCRIPT"
           rm -f "$SCRIPT"

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -207,21 +207,79 @@ jobs:
             fi
           fi
 
+      - name: 🛠️ Install create-dmg
+        if: contains(matrix.os, 'macos')
+        run: brew install create-dmg
+
+      - name: 📦 Build DMG
+        if: contains(matrix.os, 'macos')
+        shell: bash
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          if [ -n "${{ inputs.tagName }}" ]; then
+            VERSION_NAME="${{ inputs.tagName }}"
+          else
+            VERSION_NAME="$VERSION"
+          fi
+          STAGING="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}"
+          APP_NAME="mDNS TUI Browser.app"
+          DMG_NAME="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}.dmg"
+          mkdir -p "$STAGING/$APP_NAME/Contents/MacOS"
+          cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$STAGING/$APP_NAME/Contents/MacOS/"
+          cp LICENSE "$STAGING/$APP_NAME/Contents/Resources/"
+          cat > "$STAGING/$APP_NAME/Contents/Info.plist" << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleExecutable</key>
+            <string>mdns-tui-browser</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.mdns-tui-browser.app</string>
+            <key>CFBundleName</key>
+            <string>mDNS TUI Browser</string>
+            <key>CFBundleVersion</key>
+            <string>1</string>
+            <key>CFBundleShortVersionString</key>
+            <string>1.0</string>
+            <key>CFBundlePackageType</key>
+            <string>APPL</string>
+            <key>LSMinimumSystemVersion</key>
+            <string>10.13</string>
+            <key>LSApplicationCategoryType</key>
+            <string>public.app-category.utilities</string>
+          </dict>
+          </plist>
+          EOF
+          create-dmg --volname "mDNS TUI Browser" \
+                    --window-pos 200 120 \
+                    --window-size 600 400 \
+                    --icon-size 100 \
+                    --icon "$APP_NAME" 150 \
+                    --app-drop-link 425 150 \
+                    "$DMG_NAME" \
+                    "$STAGING/"
+          echo "DMG_ASSET=$DMG_NAME" >> "$GITHUB_ENV"
+
       - name: 🧮 Compute attestation subjects
-        if: inputs.tagName && contains(matrix.os, 'ubuntu')
+        if: inputs.tagName && (contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos'))
         shell: bash
         run: |
           if [ -n "${{ env.IPK_ASSET }}" ]; then
             echo "ATTESTATION_SUBJECTS=${{ env.ASSET }},${{ env.DEB_ASSET }},${{ env.IPK_ASSET }}" >> "$GITHUB_ENV"
-          else
+          elif [ -n "${{ env.DMG_ASSET }}" ]; then
+            echo "ATTESTATION_SUBJECTS=${{ env.ASSET }},${{ env.DMG_ASSET }}" >> "$GITHUB_ENV"
+          elif [ -n "${{ env.DEB_ASSET }}" ]; then
             echo "ATTESTATION_SUBJECTS=${{ env.ASSET }},${{ env.DEB_ASSET }}" >> "$GITHUB_ENV"
+          else
+            echo "ATTESTATION_SUBJECTS=${{ env.ASSET }}" >> "$GITHUB_ENV"
           fi
 
       - name: 🔐 Generate provenance attestation
         if: inputs.tagName
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
-          subject-path: ${{ matrix.os == 'ubuntu-latest' && env.ATTESTATION_SUBJECTS || env.ASSET }}
+          subject-path: ${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && env.ATTESTATION_SUBJECTS || env.ASSET }}
 
       - name: 🚀 Publish release assets
         if: inputs.tagName
@@ -238,6 +296,7 @@ jobs:
             ${{ env.ASSET }}
             ${{ contains(matrix.os, 'ubuntu') && env.DEB_ASSET || '' }}
             ${{ matrix.os == 'ubuntu-latest' && (matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'arm-unknown-linux-gnueabihf') && env.IPK_ASSET || '' }}
+            ${{ contains(matrix.os, 'macos') && env.DMG_ASSET || '' }}
 
       - name: 📦 Upload artifacts
         if: (!inputs.tagName)
@@ -261,4 +320,12 @@ jobs:
         with:
           name: mdns-tui-browser-${{ matrix.target }}-ipk
           path: ${{ env.IPK_ASSET }}
+          retention-days: 30
+
+      - name: 📦 Upload DMG artifacts
+        if: (!inputs.tagName) && contains(matrix.os, 'macos') && env.DMG_ASSET != ''
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: mdns-tui-browser-${{ matrix.target }}-dmg
+          path: ${{ env.DMG_ASSET }}
           retention-days: 30

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -242,7 +242,7 @@ jobs:
           SCRIPT=$(mktemp)
           EXE_PATH="$(cd "$(dirname "$0")" && pwd)/mdns-tui-browser"
           printf -v QUOTED_EXE 'quoted form of "%s"' "$EXE_PATH"
-          printf -v SCRIPT_TEXT 'tell app "Terminal" to do script %s\n' "$QUOTED_EXE"
+          printf -v SCRIPT_TEXT 'tell app "Terminal" to do script "exec %s"\n' "$QUOTED_EXE"
           echo "$SCRIPT_TEXT" > "$SCRIPT"
           osascript "$SCRIPT"
           rm -f "$SCRIPT"

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -242,7 +242,7 @@ jobs:
           SCRIPT=$(mktemp)
           EXE_PATH="$(cd "$(dirname "$0")" && pwd)/mdns-tui-browser"
           printf -v QUOTED_EXE 'quoted form of "%s"' "$EXE_PATH"
-          printf -v SCRIPT_TEXT 'tell app "Terminal" to do script "exec %s"\n' "$QUOTED_EXE"
+          printf -v SCRIPT_TEXT 'tell app "Terminal" to do script "%s; exit"\n' "$EXE_PATH"
           echo "$SCRIPT_TEXT" > "$SCRIPT"
           osascript "$SCRIPT"
           rm -f "$SCRIPT"

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -272,6 +272,8 @@ jobs:
           </dict>
           </plist>
           EOF
+          # Self-sign the app bundle before packaging into DMG
+          codesign --force --deep --sign - "$DMG_STAGING/$APP_NAME"
           create-dmg --volname "mDNS TUI Browser" \
                     --window-pos 200 120 \
                     --window-size 600 400 \
@@ -280,9 +282,7 @@ jobs:
                     --app-drop-link 425 150 \
                     "$DMG_NAME" \
                     "$DMG_STAGING/"
-          # Self-sign the app bundle (ad-hoc signing)
-          codesign --force --deep --sign - "$DMG_STAGING/$APP_NAME"
-          # Sign the DMG
+          # Self-sign the DMG (the app inside was already signed during build)
           codesign --force --sign - "$DMG_NAME"
           # Clean up DMG staging
           rm -rf "$DMG_STAGING"
@@ -306,7 +306,7 @@ jobs:
         if: inputs.tagName
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
-          subject-path: ${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && env.ATTESTATION_SUBJECTS || env.ASSET }}
+          subject-path: ${{ (contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')) && env.ATTESTATION_SUBJECTS || env.ASSET }}
 
       - name: 🚀 Publish release assets
         if: inputs.tagName

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -229,14 +229,14 @@ jobs:
           else
             VERSION_NAME="$VERSION"
           fi
-          STAGING="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}"
+          DMG_STAGING="mdns-tui-browser-dmg-${VERSION_NAME}-${{ matrix.platform }}"
           APP_NAME="mDNS TUI Browser.app"
           DMG_NAME="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}.dmg"
-          mkdir -p "$STAGING/$APP_NAME/Contents/MacOS"
-          mkdir -p "$STAGING/$APP_NAME/Contents/Resources"
-          cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$STAGING/$APP_NAME/Contents/MacOS/"
-          cp LICENSE "$STAGING/$APP_NAME/Contents/Resources/"
-          cat > "$STAGING/$APP_NAME/Contents/Info.plist" << EOF
+          mkdir -p "$DMG_STAGING/$APP_NAME/Contents/MacOS"
+          mkdir -p "$DMG_STAGING/$APP_NAME/Contents/Resources"
+          cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$DMG_STAGING/$APP_NAME/Contents/MacOS/"
+          cp LICENSE "$DMG_STAGING/$APP_NAME/Contents/Resources/"
+          cat > "$DMG_STAGING/$APP_NAME/Contents/Info.plist" << EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -267,11 +267,13 @@ jobs:
                     --icon "$APP_NAME" 150 150 \
                     --app-drop-link 425 150 \
                     "$DMG_NAME" \
-                    "$STAGING/"
+                    "$DMG_STAGING/"
           # Self-sign the app bundle (ad-hoc signing)
-          codesign --force --deep --sign - "$STAGING/$APP_NAME"
+          codesign --force --deep --sign - "$DMG_STAGING/$APP_NAME"
           # Sign the DMG
           codesign --force --sign - "$DMG_NAME"
+          # Clean up DMG staging
+          rm -rf "$DMG_STAGING"
           echo "DMG_ASSET=$DMG_NAME" >> "$GITHUB_ENV"
 
       - name: 🧮 Compute attestation subjects

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -158,8 +158,8 @@ jobs:
             cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$staging/"
             cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$staging/" || true
             cp -LR "target/${{ matrix.target }}/release/mdns-tui-browser.dSYM" "$staging/" || true
-            # Include manpage for Unix-like builds (Linux and macOS)
-            if [[ "${{ matrix.os }}" == "ubuntu-latest" || "${{ matrix.os }}" == "macos-latest" ]]; then
+            # Include manpage for Linux builds only
+            if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
               mkdir -p "$staging/man/man1"
               cp "docs/mdns-tui-browser.1" "$staging/man/man1/"
             fi
@@ -241,13 +241,8 @@ jobs:
           # Create a shell script wrapper that launches Terminal with the TUI app
           cat > "$DMG_STAGING/$APP_NAME/Contents/MacOS/run" << 'WRAPPER'
           #!/bin/bash
-          SCRIPT=$(mktemp)
           EXE_PATH="$(cd "$(dirname "$0")" && pwd)/mdns-tui-browser"
-          printf -v QUOTED_EXE 'quoted form of "%s"' "$EXE_PATH"
-          printf -v SCRIPT_TEXT 'tell app "Terminal" to do script %s & "; exit"\n' "$QUOTED_EXE"
-          echo "$SCRIPT_TEXT" > "$SCRIPT"
-          osascript "$SCRIPT"
-          rm -f "$SCRIPT"
+          osascript -e 'tell app "Terminal"' -e "do script \"$EXE_PATH; exit\"" -e 'end tell'
           WRAPPER
           chmod +x "$DMG_STAGING/$APP_NAME/Contents/MacOS/run"
           # Set the wrapper as the executable in Info.plist

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -136,6 +136,7 @@ jobs:
           else
             VERSION_NAME="$VERSION"
           fi
+          echo "VERSION_NAME=$VERSION_NAME" >> "$GITHUB_ENV"
           # Use platform for tarball, but preserve original .deb name on Linux
           staging="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}"
           mkdir -p "$staging"
@@ -217,18 +218,19 @@ jobs:
 
       - name: 🛠️ Install create-dmg
         if: contains(matrix.os, 'macos')
-        run: brew install create-dmg
+        run: |
+          CREATE_DMG_VERSION="v1.1.0"
+          git clone --depth 1 --branch "$CREATE_DMG_VERSION" https://github.com/create-dmg/create-dmg.git /tmp/create-dmg
+          cd /tmp/create-dmg
+          make
+          sudo cp create-dmg /usr/local/bin/
+          cd -
+          rm -rf /tmp/create-dmg
 
       - name: 📦 Build DMG
         if: contains(matrix.os, 'macos')
         shell: bash
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          if [ -n "${{ inputs.tagName }}" ]; then
-            VERSION_NAME="${{ inputs.tagName }}"
-          else
-            VERSION_NAME="$VERSION"
-          fi
           DMG_STAGING="mdns-tui-browser-dmg-${VERSION_NAME}-${{ matrix.platform }}"
           APP_NAME="mDNS-TUI-Browser.app"
           DMG_NAME="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}.dmg"
@@ -354,7 +356,7 @@ jobs:
 
       - name: 📦 Upload DMG artifacts
         if: (!inputs.tagName) && contains(matrix.os, 'macos') && env.DMG_ASSET != ''
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mdns-tui-browser-${{ matrix.target }}-dmg
           path: ${{ env.DMG_ASSET }}

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -159,7 +159,7 @@ jobs:
             cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$staging/" || true
             cp -LR "target/${{ matrix.target }}/release/mdns-tui-browser.dSYM" "$staging/" || true
             # Include manpage for Linux builds only
-            if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            if [[ "${{ matrix.os }}" =~ ^ubuntu ]]; then
               mkdir -p "$staging/man/man1"
               cp "docs/mdns-tui-browser.1" "$staging/man/man1/"
             fi

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -146,15 +146,8 @@ jobs:
             7z a -tzip "$staging.zip" "$staging"
             echo "ASSET=$staging.zip" >> "$GITHUB_ENV"
           elif [ "${{ matrix.os }}" = "macos-latest" ]; then
-            cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$staging/"
-            cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$staging/" || true
-            cp -LR "target/${{ matrix.target }}/release/mdns-tui-browser.dSYM" "$staging/" || true
-            mkdir -p "$staging/man/man1"
-            cp "docs/mdns-tui-browser.1" "$staging/man/man1/"
-            DMG_NAME="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}.dmg"
-            cp "$DMG_NAME" "$staging/"
-            tar czf "$staging.tar.gz" "$staging"
-            echo "ASSET=$staging.tar.gz" >> "$GITHUB_ENV"
+            # For macOS, tarball is created after DMG build (see below)
+            echo "ASSET=" >> "$GITHUB_ENV"
           else
             cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$staging/"
             cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$staging/" || true
@@ -270,6 +263,16 @@ jobs:
                     --app-drop-link 425 150 \
                     "$DMG_NAME" \
                     "$STAGING/"
+          # Copy binary, symbols, manpage, and DMG to staging for tarball
+          cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$STAGING/"
+          cp "target/${{ matrix.target }}/release/mdns-tui-browser.dwp" "$STAGING/" || true
+          cp -LR "target/${{ matrix.target }}/release/mdns-tui-browser.dSYM" "$STAGING/" || true
+          mkdir -p "$STAGING/man/man1"
+          cp "docs/mdns-tui-browser.1" "$STAGING/man/man1/"
+          cp "$DMG_NAME" "$STAGING/"
+          # Create tarball with all artifacts including DMG
+          tar czf "$STAGING.tar.gz" "$STAGING"
+          echo "ASSET=$STAGING.tar.gz" >> "$GITHUB_ENV"
           echo "DMG_ASSET=$DMG_NAME" >> "$GITHUB_ENV"
 
       - name: 🧮 Compute attestation subjects

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -225,9 +225,10 @@ jobs:
           APP_NAME="mDNS TUI Browser.app"
           DMG_NAME="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}.dmg"
           mkdir -p "$STAGING/$APP_NAME/Contents/MacOS"
+          mkdir -p "$STAGING/$APP_NAME/Contents/Resources"
           cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$STAGING/$APP_NAME/Contents/MacOS/"
           cp LICENSE "$STAGING/$APP_NAME/Contents/Resources/"
-          cat > "$STAGING/$APP_NAME/Contents/Info.plist" << 'EOF'
+          cat > "$STAGING/$APP_NAME/Contents/Info.plist" << EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -239,9 +240,9 @@ jobs:
             <key>CFBundleName</key>
             <string>mDNS TUI Browser</string>
             <key>CFBundleVersion</key>
-            <string>1</string>
+            <string>${VERSION_NAME}</string>
             <key>CFBundleShortVersionString</key>
-            <string>1.0</string>
+            <string>${VERSION_NAME}</string>
             <key>CFBundlePackageType</key>
             <string>APPL</string>
             <key>LSMinimumSystemVersion</key>
@@ -255,7 +256,7 @@ jobs:
                     --window-pos 200 120 \
                     --window-size 600 400 \
                     --icon-size 100 \
-                    --icon "$APP_NAME" 150 \
+                    --icon "$APP_NAME" 150 150 \
                     --app-drop-link 425 150 \
                     "$DMG_NAME" \
                     "$STAGING/"

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -236,13 +236,23 @@ jobs:
           mkdir -p "$DMG_STAGING/$APP_NAME/Contents/Resources"
           cp "target/${{ matrix.target }}/release/mdns-tui-browser" "$DMG_STAGING/$APP_NAME/Contents/MacOS/"
           cp LICENSE "$DMG_STAGING/$APP_NAME/Contents/Resources/"
+          # Create a shell script wrapper that launches Terminal with the TUI app
+          cat > "$DMG_STAGING/$APP_NAME/Contents/MacOS/run" << 'WRAPPER'
+          #!/bin/bash
+          SCRIPT=$(mktemp)
+          echo 'tell app "Terminal" to do script "'"$(dirname "$0")/mdns-tui-browser"'"' > "$SCRIPT"
+          osascript "$SCRIPT"
+          rm -f "$SCRIPT"
+          WRAPPER
+          chmod +x "$DMG_STAGING/$APP_NAME/Contents/MacOS/run"
+          # Set the wrapper as the executable in Info.plist
           cat > "$DMG_STAGING/$APP_NAME/Contents/Info.plist" << EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
           <dict>
             <key>CFBundleExecutable</key>
-            <string>mdns-tui-browser</string>
+            <string>run</string>
             <key>CFBundleIdentifier</key>
             <string>com.mdns-tui-browser.app</string>
             <key>CFBundleName</key>
@@ -257,6 +267,8 @@ jobs:
             <string>10.13</string>
             <key>LSApplicationCategoryType</key>
             <string>public.app-category.utilities</string>
+            <key>LSBackgroundOnly</key>
+            <true/>
           </dict>
           </plist>
           EOF

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -240,7 +240,8 @@ jobs:
           cat > "$DMG_STAGING/$APP_NAME/Contents/MacOS/run" << 'WRAPPER'
           #!/bin/bash
           SCRIPT=$(mktemp)
-          echo 'tell app "Terminal" to do script "'"$(dirname "$0")/mdns-tui-browser"'"' > "$SCRIPT"
+          EXE_PATH="$(cd "$(dirname "$0")" && pwd)/mdns-tui-browser"
+          echo "tell app \"Terminal\" to do script \"$EXE_PATH\"" > "$SCRIPT"
           osascript "$SCRIPT"
           rm -f "$SCRIPT"
           WRAPPER

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -230,7 +230,7 @@ jobs:
             VERSION_NAME="$VERSION"
           fi
           DMG_STAGING="mdns-tui-browser-dmg-${VERSION_NAME}-${{ matrix.platform }}"
-          APP_NAME="mDNS TUI Browser.app"
+          APP_NAME="mDNS-TUI-Browser.app"
           DMG_NAME="mdns-tui-browser-${VERSION_NAME}-${{ matrix.platform }}.dmg"
           mkdir -p "$DMG_STAGING/$APP_NAME/Contents/MacOS"
           mkdir -p "$DMG_STAGING/$APP_NAME/Contents/Resources"
@@ -241,7 +241,7 @@ jobs:
           #!/bin/bash
           SCRIPT=$(mktemp)
           EXE_PATH="$(cd "$(dirname "$0")" && pwd)/mdns-tui-browser"
-          printf -v QUOTED_EXE '%s' "$(osascript -e "quoted form of \"$EXE_PATH\"")"
+          printf -v QUOTED_EXE 'quoted form of "%s"' "$EXE_PATH"
           printf -v SCRIPT_TEXT 'tell app "Terminal" to do script %s & "; exit"\n' "$QUOTED_EXE"
           echo "$SCRIPT_TEXT" > "$SCRIPT"
           osascript "$SCRIPT"

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -241,7 +241,9 @@ jobs:
           #!/bin/bash
           SCRIPT=$(mktemp)
           EXE_PATH="$(cd "$(dirname "$0")" && pwd)/mdns-tui-browser"
-          echo "tell app \"Terminal\" to do script \"$EXE_PATH\"" > "$SCRIPT"
+          printf -v QUOTED_EXE 'quoted form of "%s"' "$EXE_PATH"
+          printf -v SCRIPT_TEXT 'tell app "Terminal" to do script %s\n' "$QUOTED_EXE"
+          echo "$SCRIPT_TEXT" > "$SCRIPT"
           osascript "$SCRIPT"
           rm -f "$SCRIPT"
           WRAPPER


### PR DESCRIPTION
## Summary
- Extends the build workflow to create .dmg packages for macOS (both aarch64 and x86_64)
- Uses `create-dmg` to package the binary as a macOS app bundle
- Adds attestation support for macOS assets
- Includes DMG in release assets and artifact uploads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native macOS installers (versioned DMG) and multi‑platform tar.gz archives; macOS builds produce a self-contained app bundle with a Terminal-launch wrapper and included licensing.

* **Chores**
  * Release pipeline now builds, signs, and publishes macOS DMG and tar.gz assets, uploads DMGs for non-tag runs, includes manpage only for Linux archives, and incorporates macOS artifacts into provenance/attestation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->