### PR TITLE
doc: update instructions to validate renovate config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ typos
 actionlint
 
 # Validate renovate configuration
-docker run --rm -v "$(pwd):/repo" -w /repo ghcr.io/renovatebot/renovate:full renovate-config-validator .github/renovate.json5
+docker run --rm -v "$(pwd):/repo" -w /repo ghcr.io/renovatebot/renovate renovate-config-validator .github/renovate.json5
 ```
 
 ## Code Style Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ typos
 actionlint
 
 # Validate renovate configuration
-docker run --rm -v "$(pwd):/repo" -w /repo ghcr.io/renovatebot/renovate renovate-config-validator .github/renovate.json5
+docker run --rm --volume=$(pwd):$(pwd):ro --workdir=$(pwd) kokuwaio/renovate-config-validator:latest
 ```
 
 ## Code Style Guidelines


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated instructions replacing the prior Docker-based Renovate configuration validation command with a different validator image. The guidance now shows running the validator with a read-only workspace mount, setting the container work directory to the project path, and using a simpler invocation (omitting an explicit config-path). This clarifies and streamlines local configuration validation for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->