### PR TITLE
fix: ignore meta service as type when browsing

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -10,6 +10,8 @@ use chrono::{DateTime, Utc};
 use mdns_sd::{ResolvedService, ScopedIp};
 use serde::{Deserialize, Serialize};
 
+pub const MDNS_SD_META_SERVICE: &str = "_services._dns-sd._udp.local.";
+
 pub fn format_ip_for_display(ip: &ScopedIp) -> String {
     match ip {
         ScopedIp::V4(v4) => v4.addr().to_string(),

--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -2808,11 +2808,8 @@ pub async fn run_tui(
                             }
                             ServiceEvent::ServiceFound(_service_type, fullname) => {
                                 let service_type = fullname.to_string();
-                                if is_sub_type(&service_type) {
-                                    continue; // skip subtypes in auto-discovery
-                                }
-                                if service_type == MDNS_SD_META_SERVICE {
-                                    continue;
+                                if is_sub_type(&service_type) || service_type == MDNS_SD_META_SERVICE {
+                                    continue; // skip subtypes and meta-services in auto-discovery
                                 }
                                 {
                                     let mut state = state_clone.write().await;

--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -2808,7 +2808,9 @@ pub async fn run_tui(
                             }
                             ServiceEvent::ServiceFound(_service_type, fullname) => {
                                 let service_type = fullname.to_string();
-                                if is_sub_type(&service_type) || service_type == MDNS_SD_META_SERVICE {
+                                if is_sub_type(&service_type)
+                                    || service_type == MDNS_SD_META_SERVICE
+                                {
                                     continue; // skip subtypes and meta-services in auto-discovery
                                 }
                                 {

--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -20,8 +20,8 @@ use tokio::sync::RwLock;
 
 use crate::input::InputState;
 use crate::models::{
-    AppOptions, FilterInfo, Metadata, ServiceEntry, SortDirection, SortField, SortInfo, StateDump,
-    current_timestamp_micros, format_ip_for_display, format_service_addrs,
+    AppOptions, FilterInfo, MDNS_SD_META_SERVICE, Metadata, ServiceEntry, SortDirection, SortField,
+    SortInfo, StateDump, current_timestamp_micros, format_ip_for_display, format_service_addrs,
 };
 use crate::popup::PopupState;
 use crate::scroll::ScrollState;
@@ -2793,7 +2793,7 @@ pub async fn run_tui(
         if state.read().await.user_service_types.is_empty() {
             // Browse for all service types
             if let Some(ref mdns_ref) = mdns {
-                let receiver = mdns_ref.browse("_services._dns-sd._udp.local.")?;
+                let receiver = mdns_ref.browse(MDNS_SD_META_SERVICE)?;
 
                 let mdns = mdns.clone();
                 tokio::spawn(async move {
@@ -2810,6 +2810,9 @@ pub async fn run_tui(
                                 let service_type = fullname.to_string();
                                 if is_sub_type(&service_type) {
                                     continue; // skip subtypes in auto-discovery
+                                }
+                                if service_type == MDNS_SD_META_SERVICE {
+                                    continue;
                                 }
                                 {
                                     let mut state = state_clone.write().await;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a centralized mDNS service type constant to replace hardcoded configuration values, enhancing code maintainability and consistency across the discovery module.
  * Strengthened service discovery filtering by adding explicit logic to exclude meta-service entries, ensuring more accurate and refined discovery results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->