### PR TITLE
feat: add homebrew tap release automation workflow

### DIFF
--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -28,18 +28,16 @@ jobs:
           TAG_NAME: ${{ steps.release-info.outputs.tagName }}
           VERSION: ${{ steps.release-info.outputs.version }}
         run: |
-          INTEL_URL="https://github.com/hrzlgnm/mdns-tui-browser/releases/download/${TAG_NAME}/mdns-tui-browser-${TAG_NAME}-x86_64-apple-darwin.tar.gz"
-          ARM64_URL="https://github.com/hrzlgnm/mdns-tui-browser/releases/download/${TAG_NAME}/mdns-tui-browser-${TAG_NAME}-aarch64-apple-darwin.tar.gz"
+          INTEL_URL="https://github.com/hrzlgnm/mdns-tui-browser/releases/download/${TAG_NAME}/mdns-tui-browser-${TAG_NAME}-macOS-x86_64.dmg"
+          ARM64_URL="https://github.com/hrzlgnm/mdns-tui-browser/releases/download/${TAG_NAME}/mdns-tui-browser-${TAG_NAME}-macOS-aarch64.dmg"
 
-          curl -fsSL -o intel.tar.gz "$INTEL_URL"
-          curl -fsSL -o arm64.tar.gz "$ARM64_URL"
+          curl -fsSL -o intel.dmg "$INTEL_URL"
+          curl -fsSL -o arm64.dmg "$ARM64_URL"
 
-          INTEL_SHA=$(sha256sum intel.tar.gz | awk '{print $1}')
-          ARM64_SHA=$(sha256sum arm64.tar.gz | awk '{print $1}')
+          INTEL_SHA=$(sha256sum intel.dmg | awk '{print $1}')
+          ARM64_SHA=$(sha256sum arm64.dmg | awk '{print $1}')
 
           {
-            echo "INTEL_URL=$INTEL_URL"
-            echo "ARM64_URL=$ARM64_URL"
             echo "INTEL_SHA=$INTEL_SHA"
             echo "ARM64_SHA=$ARM64_SHA"
             echo "VERSION=$VERSION"
@@ -52,7 +50,7 @@ jobs:
           echo "Apple Silicon URL: $ARM64_URL"
           echo "Apple Silicon SHA256: $ARM64_SHA"
 
-          rm -f intel.tar.gz arm64.tar.gz
+          rm -f intel.dmg arm64.dmg
 
       - name: 🔄 Checkout Homebrew Tap
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -62,22 +60,18 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           fetch-depth: 1
 
-      - name: 🔧 Update formula
+      - name: 🔧 Update cask
         shell: bash
         env:
           VERSION: ${{ env.VERSION }}
-          INTEL_URL: ${{ env.INTEL_URL }}
           INTEL_SHA: ${{ env.INTEL_SHA }}
-          ARM64_URL: ${{ env.ARM64_URL }}
           ARM64_SHA: ${{ env.ARM64_SHA }}
         run: |
-          FORMULA_PATH="../homebrew-tap/Formula/mdns-tui-browser.rb"
-          sed -i "s|{{VERSION}}|$VERSION|g" "$FORMULA_PATH"
-          sed -i "s|{{X86_64_URL}}|$INTEL_URL|g" "$FORMULA_PATH"
-          sed -i "s|{{X86_64_SHA256}}|$INTEL_SHA|g" "$FORMULA_PATH"
-          sed -i "s|{{ARM64_URL}}|$ARM64_URL|g" "$FORMULA_PATH"
-          sed -i "s|{{ARM64_SHA256}}|$ARM64_SHA|g" "$FORMULA_PATH"
-          cat "$FORMULA_PATH"
+          CASK_PATH="../homebrew-tap/Casks/mdns-tui-browser.rb"
+          sed -i "s|version \".*\"|version \"$VERSION\"|" "$CASK_PATH"
+          sed -i "s|sha256 arm:.*|sha256 arm:   \"$ARM64_SHA\",|" "$CASK_PATH"
+          sed -i "s|intel: \".*\"|intel: \"$INTEL_SHA\"|" "$CASK_PATH"
+          cat "$CASK_PATH"
 
       - name: 🚀 Commit and push to tap repo
         shell: bash
@@ -90,7 +84,7 @@ jobs:
           if git diff --quiet; then
             echo "No changes to commit"
           else
-            git add Formula/mdns-tui-browser.rb
+            git add Casks/mdns-tui-browser.rb
             git commit -m "chore: update mdns-tui-browser to $VERSION"
             git push
           fi

--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -1,0 +1,96 @@
+# Copyright 2026 hrzlgnm
+# SPDX-License-Identifier: MIT-0
+
+name: Publish Release to Homebrew Tap
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: 🏷️ Get latest release info
+        id: release-info
+        uses: ./.github/actions/latest-release-info
+
+      - name: 🛠️ Determine download URLs and compute SHA256
+        shell: bash
+        env:
+          TAG_NAME: ${{ steps.release-info.outputs.tagName }}
+          VERSION: ${{ steps.release-info.outputs.version }}
+        run: |
+          INTEL_URL="https://github.com/hrzlgnm/mdns-tui-browser/releases/download/${TAG_NAME}/mdns-tui-browser-${TAG_NAME}-x86_64-apple-darwin.tar.gz"
+          ARM64_URL="https://github.com/hrzlgnm/mdns-tui-browser/releases/download/${TAG_NAME}/mdns-tui-browser-${TAG_NAME}-aarch64-apple-darwin.tar.gz"
+
+          curl -fsSL -o intel.tar.gz "$INTEL_URL"
+          curl -fsSL -o arm64.tar.gz "$ARM64_URL"
+
+          INTEL_SHA=$(sha256sum intel.tar.gz | awk '{print $1}')
+          ARM64_SHA=$(sha256sum arm64.tar.gz | awk '{print $1}')
+
+          {
+            echo "INTEL_URL=$INTEL_URL"
+            echo "ARM64_URL=$ARM64_URL"
+            echo "INTEL_SHA=$INTEL_SHA"
+            echo "ARM64_SHA=$ARM64_SHA"
+            echo "VERSION=$VERSION"
+          } >> "$GITHUB_ENV"
+
+          echo "Detected latest tag name: $TAG_NAME"
+          echo "Version: $VERSION"
+          echo "Intel URL: $INTEL_URL"
+          echo "Intel SHA256: $INTEL_SHA"
+          echo "Apple Silicon URL: $ARM64_URL"
+          echo "Apple Silicon SHA256: $ARM64_SHA"
+
+          rm -f intel.tar.gz arm64.tar.gz
+
+      - name: 🔄 Checkout Homebrew Tap
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: hrzlgnm/homebrew-tap
+          path: ../homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          fetch-depth: 1
+
+      - name: 🔧 Update formula
+        shell: bash
+        env:
+          VERSION: ${{ env.VERSION }}
+          INTEL_URL: ${{ env.INTEL_URL }}
+          INTEL_SHA: ${{ env.INTEL_SHA }}
+          ARM64_URL: ${{ env.ARM64_URL }}
+          ARM64_SHA: ${{ env.ARM64_SHA }}
+        run: |
+          FORMULA_PATH="../homebrew-tap/Formula/mdns-tui-browser.rb"
+          sed -i "s|{{VERSION}}|$VERSION|g" "$FORMULA_PATH"
+          sed -i "s|{{X86_64_URL}}|$INTEL_URL|g" "$FORMULA_PATH"
+          sed -i "s|{{X86_64_SHA256}}|$INTEL_SHA|g" "$FORMULA_PATH"
+          sed -i "s|{{ARM64_URL}}|$ARM64_URL|g" "$FORMULA_PATH"
+          sed -i "s|{{ARM64_SHA256}}|$ARM64_SHA|g" "$FORMULA_PATH"
+          cat "$FORMULA_PATH"
+
+      - name: 🚀 Commit and push to tap repo
+        shell: bash
+        env:
+          VERSION: ${{ env.VERSION }}
+        run: |
+          cd ../homebrew-tap
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          if git diff --quiet; then
+            echo "No changes to commit"
+          else
+            git add Formula/mdns-tui-browser.rb
+            git commit -m "chore: update mdns-tui-browser to $VERSION"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ yay -S mdns-tui-browser
 
 This will install the latest version from the AUR and handle updates automatically with your regular system updates.
 
+### Install using Homebrew (macOS)
+
+You can install `mdns-tui-browser` via Homebrew:
+
+```bash
+# Tap the repository first
+brew tap hrzlgnm/tap
+brew install --cask mdns-tui-browser
+```
+
+Or install directly without tapping:
+```bash
+brew install --cask hrzlgnm/tap/mdns-tui-browser
+```
+
+This will install the latest version from the Homebrew tap and handle updates automatically with `brew upgrade`.
+
 ### Install using winget on Windows
 
 You can install `mdns-tui-browser` from Winget Packages using `winget`:


### PR DESCRIPTION
## Summary
- Add Homebrew tap release automation workflow (`.github/workflows/homebrew-reusable.yml`)
- Workflow triggers on release published and updates the Homebrew tap Cask with correct URLs and SHA256 hashes
- Mirrors structure of `winget-reusable.yml` but for macOS-only Homebrew distribution via Cask
- Validated with `actionlint` (no warnings)
- Add Homebrew installation instructions to README.md

## Changes
- New workflow file: `.github/workflows/homebrew-reusable.yml`
- Downloads macOS DMG release assets (Intel + Apple Silicon)
- Computes SHA256 hashes
- Updates Cask in `hrzlgnm/homebrew-tap` repository
- Updated README.md with Homebrew installation instructions

## Installation (after merge)
```bash
brew tap hrzlgnm/tap
brew install --cask mdns-tui-browser
```

## Testing
- Workflow syntax validated with `actionlint`
- No Rust code changes, so no `cargo fmt`/`clippy`/`nextest` needed