### PR TITLE
fix: strip v prefix and correct sed patterns for homebrew workflow

### DIFF
--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -40,7 +40,7 @@ jobs:
           {
             echo "INTEL_SHA=$INTEL_SHA"
             echo "ARM64_SHA=$ARM64_SHA"
-            echo "VERSION=$VERSION"
+            echo "VERSION=${VERSION#v}"
           } >> "$GITHUB_ENV"
 
           echo "Detected latest tag name: $TAG_NAME"
@@ -68,8 +68,8 @@ jobs:
           ARM64_SHA: ${{ env.ARM64_SHA }}
         run: |
           CASK_PATH="homebrew-tap/Casks/mdns-tui-browser.rb"
-          sed -i "s|version \".*\"|version \"$VERSION\"|" "$CASK_PATH"
-          sed -i "s|sha256 arm:.*|sha256 arm:   \"$ARM64_SHA\",|" "$CASK_PATH"
+          sed -i "s|^  version \".*\"|  version \"$VERSION\"|" "$CASK_PATH"
+          sed -i "s|^  sha256 arm:.*|  sha256 arm:   \"$ARM64_SHA\",|" "$CASK_PATH"
           sed -i "s|intel: \".*\"|intel: \"$INTEL_SHA\"|" "$CASK_PATH"
           cat "$CASK_PATH"
 


### PR DESCRIPTION
## Summary
- Strip `v` prefix from version before writing to Cask (Homebrew versions don't include `v`)
- Fix sed patterns to match leading whitespace in Cask file
- Ensures `version "1.30.5"` is written instead of `version "v1.30.5"`

## Changes
- Modified `.github/workflows/homebrew-reusable.yml`:
  - Added `${VERSION#v}` to strip `v` prefix from version
  - Updated sed patterns to match `  version` and `  sha256 arm:` with leading spaces

## Testing
- Workflow syntax validated with `actionlint`
- Fixes version handling for Homebrew Cask updates