### PR TITLE
fix: prevent sed from corrupting arch stanza when updating sha256

### DIFF
--- a/.github/workflows/homebrew-reusable.yml
+++ b/.github/workflows/homebrew-reusable.yml
@@ -70,7 +70,7 @@ jobs:
           CASK_PATH="homebrew-tap/Casks/mdns-tui-browser.rb"
           sed -i "s|^  version \".*\"|  version \"$VERSION\"|" "$CASK_PATH"
           sed -i "s|^  sha256 arm:.*|  sha256 arm:   \"$ARM64_SHA\",|" "$CASK_PATH"
-          sed -i "s|intel: \".*\"|intel: \"$INTEL_SHA\"|" "$CASK_PATH"
+          sed -i "s|^         intel: \".*\"|         intel: \"$INTEL_SHA\"|" "$CASK_PATH"
           cat "$CASK_PATH"
 
       - name: 🚀 Commit and push to tap repo


### PR DESCRIPTION
## Summary
- Homebrew tap Cask was recently updated to use `arch arm: "aarch64", intel: "x86_64"` stanza (PR #3)
- The workflow's `intel:` sed pattern was matching both the Cask's sha256 continuation line AND the new arch stanza line, corrupting it
- Fix: anchor the sed pattern with leading whitespace (`^         intel:` with 9 spaces) to only target the sha256 line

## Changes
- Modified `.github/workflows/homebrew-reusable.yml`:
  - Changed `s|intel: ".*"|` to `s|^         intel: ".*"|` to match only indented sha256 continuation lines

## Testing
- Workflow syntax validated with `actionlint`
- Tested against current Cask to ensure arch stanza is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow configuration to enhance cask file update reliability during release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->